### PR TITLE
Sandbox 2 documentation fix

### DIFF
--- a/docs/downloads.html
+++ b/docs/downloads.html
@@ -333,7 +333,13 @@ hg update py3.5
                     <pre><code>
 pypy ../../rpython/bin/rpython -Ojit targetpypystandalone           # get the JIT version
 pypy ../../rpython/bin/rpython -O2 targetpypystandalone             # get the no-jit version
-pypy ../../rpython/bin/rpython -O2 --sandbox targetpypystandalone   # get the sandbox version
+
+# to build the pypy-sandbox, please compile the pypy JIT version first (s. first step)
+# rename the built pypy-c (and corrosponing libray libpypy-c.so) to pypy-c-jit and 
+# libpypy-c.so-jit respectively (it is needed later for packaging) and then call  
+pypy ../../rpython/bin/rpython -O2 --sandbox targetpypystandalone   # to get the sandbox version
+# rename the resulting, new pypy-c to pypy-c-sandbox (and corresponding library libpypy-c.so-sandbox) 
+# and pypy-c-jit to pypy-c  (do not forget corresponding library libpypy-c.so-jit -> libpypy-c.so)
 
 </code></pre>
                 </li>
@@ -443,6 +449,11 @@ PYPY_DONT_RUN_SUBPROCESS=1 PYPY_GC_MAX_DELTA=200MB pypy --jit loop_longevity=300
 cd ./pypy/pypy/tool/release/
 python package.py --help #for information
 python package.py --archive-name pypy-my-own-package-name
+
+# to pack the pypy-c-sandbox, a full JIT-version of pypy-c (including the corresponding library) needs to be in the goal directory 
+python package.py --archive-name pypy_my-sandbox-os --builddir ../../goal  --targetdir my/package/targetdir
+# to use the sandbox, please rename the library back to libpypy-c.so-jit and 
+# libpypy-c.so-sandbox to libpypy-c.so 
 
 </code></pre>
             <p>

--- a/docs/features.html
+++ b/docs/features.html
@@ -167,13 +167,19 @@
 
                 <p>
                     To run the sandboxed process, you need to get the full sources and
-                    build <code>pypy-sandbox</code> from it (see <a href="download.html#building-from-source">Building from source</a>). These
+                    build <code>pypy-c-sandbox</code> from it (see <a href="download.html#building-from-source">Building from source</a>). These
                     instructions give you a <code>pypy-c</code> that you should rename to
-                    <code>pypy-sandbox</code> to avoid future confusion. Then run:
+                    <code>pypy-c-sandbox</code> to avoid future confusion. 
+                    The next step ist to pack everything using the package tool like:
                 </p>
                 <pre><code>
+                    cd tool/release/
+                    python package.py --archive-name my_pypy_sandbox_package --builddir ../../goal --targetdir my/package/target/dir
+                </code> </pre>
+                <p> And finally start, e.g., an interactive pypy-sandox interpreter shell: </p>
+                <pre><code>
 cd pypy/sandbox
-pypy_interact.py path/to/pypy-sandbox
+pypy_interact.py  --lib-path=path/to/my_pypy_sandbox_package  path/to/pypy-c-sandbox -i
 # don't confuse it with pypy/goal/pyinteractive.py!
                 </code></pre>
                 <p>You get a fully sandboxed interpreter, in its own filesystem hierarchy
@@ -182,7 +188,7 @@ pypy_interact.py path/to/pypy-sandbox
                 <pre><code>
 mkdir virtualtmp
 cp untrusted.py virtualtmp/
-pypy_interact.py --tmp=virtualtmp pypy-sandbox /tmp/untrusted.py
+pypy_interact.py   --lib-path=path/to/my_pypy_sandbox_package --tmp=virtualtmp path/to/pypy-c-sandbox /tmp/untrusted.py
                 </code></pre>
                 <p>Note that the path <code>/tmp/untrusted.py</code> is a path inside the sandboxed
                     filesystem. You don't have to put <code>untrusted.py</code> in the real <code>/tmp</code>


### PR DESCRIPTION
This is an updated version of the sandbox-2 part of pypy as discussed with Armin Rigo.
It updates the descriptions of the pypy-sandbox build procedure and current usage,
since the pypy.org pages are outdated.
